### PR TITLE
Missing Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: osmium
 Section: utils
 Priority: optional
 Maintainer: Frederik Ramm <frederik@remote.org>
-Build-Depends: debhelper (>= 7), libgeos-dev, libv8-dev, libprotobuf-dev, protobuf-compiler, libshp-dev, libsparsehash-dev, libgd2-xpm-dev
+Build-Depends: debhelper (>= 7), libgeos-dev, libv8-dev, libprotobuf-dev, protobuf-compiler, libshp-dev, libsparsehash-dev, libgd2-xpm-dev, libsqlite3-dev
 Standards-Version: 3.8.0
 
 Package: osmium


### PR DESCRIPTION
`libgd-xpm-dev` and `libsqlite3-dev` were missing as Debian build dependencies.
