### PR TITLE
fix for missing callback_after_ways w/o <relation />

### DIFF
--- a/include/osmium/input/xml.hpp
+++ b/include/osmium/input/xml.hpp
@@ -106,6 +106,12 @@ namespace Osmium {
 
                 XML_ParserFree(parser);
 
+                if(last_object_type == NODE)
+                    this->handler->callback_after_nodes();
+
+                if(last_object_type == WAY)
+                    this->handler->callback_after_ways();
+
                 this->handler->callback_after_relations();
             }
 


### PR DESCRIPTION
in a test-file without <relation />s, the callback_after_ways is never fired. similar in a file without <way />s, callback_after_nodes is missing. This pull request would fix that.
