### PR TITLE
ignore input with too long ways and relations

### DIFF
--- a/include/osmium/input/xml.hpp
+++ b/include/osmium/input/xml.hpp
@@ -131,7 +131,14 @@ namespace Osmium {
                 if (!strcmp(element, "nd")) {
                     for (int count = 0; attrs[count]; count += 2) {
                         if (!strcmp(attrs[count], "ref")) {
-                            this->way->add_node(atoll(attrs[count+1]));
+                            try
+                            {
+                                this->way->add_node(atoll(attrs[count+1]));
+                            }
+                            catch(std::range_error&)
+                            {
+                                fprintf(stderr, "error reading nodes of way %d v%d (std::range_error)\n", this->way->id, this->way->version);
+                            }
                         }
                     }
                 } else if (!strcmp(element, "node")) {
@@ -168,7 +175,14 @@ namespace Osmium {
                         }
                     }
                     // XXX assert type, ref, role are set
-                    this->relation->add_member(type, ref, role);
+                    try
+                    {
+                        this->relation->add_member(type, ref, role);
+                    }
+                    catch(std::range_error&)
+                    {
+                        fprintf(stderr, "error reading members of relation %d v%d (std::range_error)\n", this->relation->id, this->relation->version);
+                    }
                 } else if (!strcmp(element, "relation")) {
                     this->call_after_and_before_handlers(RELATION);
                     init_object(this->relation, attrs);


### PR DESCRIPTION
this patch makes it possible to read the full-experimental dump, that contains pre-api06 ways with more then 2000 nodes.
