### PR TITLE
don't error on type 'long long'

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,7 +10,7 @@ CXX = g++
 CXXFLAGS = -g
 #CXXFLAGS = -O3
 
-CXXFLAGS += -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo
+CXXFLAGS += -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long
 #CXXFLAGS += -Wpadded -Winline -Weffc++ -Wold-style-cast
 
 # uncomment this if you want information on how long it took to build the multipolygons


### PR DESCRIPTION
pedanting usually errors when the type long long is used (like in the ogr headers). This patch removes this error, because it actually is a warning and the comiling works just fine with this extra flag.
