### PR TITLE
Support for optional replication fields in PBF headers

### DIFF
--- a/include/osmium/handler/debug.hpp
+++ b/include/osmium/handler/debug.hpp
@@ -49,7 +49,13 @@ namespace Osmium {
                 if (meta.has_multiple_object_versions()) {
                     m_has_multiple_object_versions = true;
                 }
-
+                if (meta.timestamp()) {
+                    time_t timestamp = meta.timestamp();
+                    std::cout << "  internal timestamp=";
+                    std::cout << ctime(&timestamp);
+                } else {
+                    std::cout << "  no timestamp" << std::endl;
+                }
                 if (meta.bounds().defined()) {
                     std::cout << "  bounds=" << meta.bounds() << "\n";
                 }

--- a/include/osmium/handler/debug.hpp
+++ b/include/osmium/handler/debug.hpp
@@ -49,12 +49,19 @@ namespace Osmium {
                 if (meta.has_multiple_object_versions()) {
                     m_has_multiple_object_versions = true;
                 }
-                if (meta.timestamp()) {
-                    time_t timestamp = meta.timestamp();
-                    std::cout << "  internal timestamp=";
+                if (meta.osmosis_replication_timestamp()) {
+                    time_t timestamp = *meta.osmosis_replication_timestamp();
+                    std::cout << "  replication timestamp=";
                     std::cout << ctime(&timestamp);
-                } else {
-                    std::cout << "  no timestamp" << std::endl;
+                }
+                if (meta.osmosis_replication_sequence_number()) {
+                    uint64_t sequence = *meta.osmosis_replication_sequence_number();
+                    std::cout << "  replication sequence number=";
+                    std::cout << sequence << std::endl;
+                }
+                if (!meta.osmosis_replication_base_url().empty()) {
+                    std::cout << "  replication base url=";
+                    std::cout << meta.osmosis_replication_base_url() << std::endl;
                 }
                 if (meta.bounds().defined()) {
                     std::cout << "  bounds=" << meta.bounds() << "\n";

--- a/include/osmium/input/pbf.hpp
+++ b/include/osmium/input/pbf.hpp
@@ -126,6 +126,9 @@ namespace Osmium {
                             if (pbf_header_block.has_writingprogram()) {
                                 this->meta().generator(pbf_header_block.writingprogram());
                             }
+                            if (pbf_header_block.has_timestamp()) {
+                                this->meta().timestamp(pbf_header_block.timestamp());
+                            }
                             if (pbf_header_block.has_bbox()) {
                                 const OSMPBF::HeaderBBox& bbox = pbf_header_block.bbox();
                                 const int64_t resolution_convert = OSMPBF::lonlat_resolution / Osmium::OSM::coordinate_precision;

--- a/include/osmium/input/pbf.hpp
+++ b/include/osmium/input/pbf.hpp
@@ -126,8 +126,14 @@ namespace Osmium {
                             if (pbf_header_block.has_writingprogram()) {
                                 this->meta().generator(pbf_header_block.writingprogram());
                             }
-                            if (pbf_header_block.has_timestamp()) {
-                                this->meta().timestamp(pbf_header_block.timestamp());
+                            if (pbf_header_block.has_osmosis_replication_timestamp()) {
+                                this->meta().osmosis_replication_timestamp(pbf_header_block.osmosis_replication_timestamp());
+                            }
+                            if (pbf_header_block.has_osmosis_replication_sequence_number()) {
+                                this->meta().osmosis_replication_sequence_number(pbf_header_block.osmosis_replication_sequence_number());
+                            }
+                            if (pbf_header_block.has_osmosis_replication_base_url()) {
+                                this->meta().osmosis_replication_base_url(pbf_header_block.osmosis_replication_base_url());
                             }
                             if (pbf_header_block.has_bbox()) {
                                 const OSMPBF::HeaderBBox& bbox = pbf_header_block.bbox();

--- a/include/osmium/osm/meta.hpp
+++ b/include/osmium/osm/meta.hpp
@@ -39,14 +39,18 @@ namespace Osmium {
                 m_bounds(),
                 m_has_multiple_object_versions(false),
                 m_generator(),
-                m_timestamp(0) {
+                m_osmosis_replication_timestamp(),
+                m_osmosis_replication_sequence_number(),
+                m_osmosis_replication_base_url() {
             }
 
             Meta(const Bounds& bounds) :
                 m_bounds(bounds),
                 m_has_multiple_object_versions(false),
                 m_generator(),
-                m_timestamp(0) {
+                m_osmosis_replication_timestamp(),
+                m_osmosis_replication_sequence_number(), 
+                m_osmosis_replication_base_url() {
             }
 
             Bounds& bounds() {
@@ -75,12 +79,32 @@ namespace Osmium {
                 return *this;
             }
 
-            time_t timestamp() const {
-                return m_timestamp;
+            boost::shared_ptr<time_t> osmosis_replication_timestamp() const {
+                return m_osmosis_replication_timestamp;
             }
 
-            Meta& timestamp(const time_t timestamp) {
-                m_timestamp = timestamp;
+            Meta& osmosis_replication_timestamp(const time_t timestamp) {
+                boost::shared_ptr<time_t> newptr(new time_t(timestamp));
+                m_osmosis_replication_timestamp = newptr;
+                return *this;
+            }
+
+            boost::shared_ptr<uint64_t> osmosis_replication_sequence_number() const {
+                return m_osmosis_replication_sequence_number;
+            }
+
+            Meta& osmosis_replication_sequence_number(const uint64_t sequence_number) {
+                boost::shared_ptr<uint64_t> newptr(new uint64_t(sequence_number));
+                m_osmosis_replication_sequence_number = newptr;
+                return *this;
+            }
+
+            const std::string& osmosis_replication_base_url() const {
+                return m_osmosis_replication_base_url;
+            }
+
+            Meta& osmosis_replication_base_url(const std::string& base_url) {
+                m_osmosis_replication_base_url = base_url;
                 return *this;
             }
 
@@ -97,8 +121,12 @@ namespace Osmium {
             /// Program that generated this file.
             std::string m_generator;
 
-            /// timestamp
-            time_t m_timestamp;
+            /// timestamp for replication
+            boost::shared_ptr<time_t> m_osmosis_replication_timestamp;
+            /// sequence number for replication
+            boost::shared_ptr<uint64_t> m_osmosis_replication_sequence_number;
+            /// base URL for replication
+            std::string m_osmosis_replication_base_url;
 
         }; // class Meta
 

--- a/include/osmium/osm/meta.hpp
+++ b/include/osmium/osm/meta.hpp
@@ -38,13 +38,15 @@ namespace Osmium {
             Meta() :
                 m_bounds(),
                 m_has_multiple_object_versions(false),
-                m_generator() {
+                m_generator(),
+                m_timestamp(0) {
             }
 
             Meta(const Bounds& bounds) :
                 m_bounds(bounds),
                 m_has_multiple_object_versions(false),
-                m_generator() {
+                m_generator(),
+                m_timestamp(0) {
             }
 
             Bounds& bounds() {
@@ -73,6 +75,15 @@ namespace Osmium {
                 return *this;
             }
 
+            time_t timestamp() const {
+                return m_timestamp;
+            }
+
+            Meta& timestamp(const time_t timestamp) {
+                m_timestamp = timestamp;
+                return *this;
+            }
+
         private:
 
             Bounds m_bounds;
@@ -85,6 +96,9 @@ namespace Osmium {
 
             /// Program that generated this file.
             std::string m_generator;
+
+            /// timestamp
+            time_t m_timestamp;
 
         }; // class Meta
 

--- a/include/osmium/output/pbf.hpp
+++ b/include/osmium/output/pbf.hpp
@@ -887,8 +887,14 @@ namespace Osmium {
                     bbox->set_top(meta.bounds().top_right().lat() * OSMPBF::lonlat_resolution);
                 }
 
-                if (meta.timestamp() != 0) {
-                    pbf_header_block.set_timestamp(meta.timestamp());
+                if (meta.osmosis_replication_timestamp()) {
+                    pbf_header_block.set_osmosis_replication_timestamp(*meta.osmosis_replication_timestamp());
+                }
+                if (meta.osmosis_replication_sequence_number()) {
+                    pbf_header_block.set_osmosis_replication_sequence_number(*meta.osmosis_replication_sequence_number());
+                }
+                if (meta.osmosis_replication_base_url().length()) {
+                    pbf_header_block.set_osmosis_replication_base_url(meta.osmosis_replication_base_url());
                 }
 
                 store_header_block();

--- a/include/osmium/output/pbf.hpp
+++ b/include/osmium/output/pbf.hpp
@@ -887,6 +887,10 @@ namespace Osmium {
                     bbox->set_top(meta.bounds().top_right().lat() * OSMPBF::lonlat_resolution);
                 }
 
+                if (meta.timestamp() != 0) {
+                    pbf_header_block.set_timestamp(meta.timestamp());
+                }
+
                 store_header_block();
             }
 


### PR DESCRIPTION
This requires the latest OSM-Binary code and adds support for the three new header fields osmosis_replication_timestamp, osmosis_replication_sequence_number, and osmosis_replication_base_url. Integers are encapsulated in boost::shared_ptr so that returning NULL is possible without using a magic value.
