### PR TITLE
64bit support

### DIFF
--- a/include/osmium/osm/types.hpp
+++ b/include/osmium/osm/types.hpp
@@ -37,7 +37,7 @@ enum osm_object_type_t {
 * numbers and still be reasonably space efficient. As the %OSM database is
 * growing rapidly, 64 bit IDs will be needed at some point!
 */
-typedef int32_t  osm_object_id_t;    ///< type for %OSM object (node, way, or relation) IDs
+typedef int64_t  osm_object_id_t;    ///< type for %OSM object (node, way, or relation) IDs
 typedef uint32_t osm_version_t;      ///< type for %OSM object version number
 typedef int32_t  osm_changeset_id_t; ///< type for %OSM changeset IDs
 typedef int32_t  osm_user_id_t;      ///< type for %OSM user IDs

--- a/include/osmium/output/xml.hpp
+++ b/include/osmium/output/xml.hpp
@@ -117,7 +117,7 @@ namespace Osmium {
                 Osmium::OSM::WayNodeList::const_iterator end = way->nodes().end();
                 for (Osmium::OSM::WayNodeList::const_iterator it = way->nodes().begin(); it != end; ++it) {
                     check_for_error(xmlTextWriterStartElement(m_xml_writer, BAD_CAST "nd")); // <nd>
-                    check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "ref", "%d", it->ref()));
+                    check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "ref", "%ld", it->ref()));
                     check_for_error(xmlTextWriterEndElement(m_xml_writer)); // </nd>
                 }
 
@@ -139,7 +139,7 @@ namespace Osmium {
                     check_for_error(xmlTextWriterStartElement(m_xml_writer, BAD_CAST "member")); // <member>
 
                     check_for_error(xmlTextWriterWriteAttribute(m_xml_writer, BAD_CAST "type", BAD_CAST it->type_name()));
-                    check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "ref", "%d", it->ref()));
+                    check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "ref", "%ld", it->ref()));
                     check_for_error(xmlTextWriterWriteAttribute(m_xml_writer, BAD_CAST "role", BAD_CAST it->role()));
 
                     check_for_error(xmlTextWriterEndElement(m_xml_writer)); // </member>
@@ -166,7 +166,7 @@ namespace Osmium {
             char m_last_op;
 
             void write_meta(const shared_ptr<Osmium::OSM::Object const>& object) {
-                check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "id",      "%d", object->id()));
+                check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "id",      "%ld", object->id()));
                 if (object->version()) {
                     check_for_error(xmlTextWriterWriteFormatAttribute(m_xml_writer, BAD_CAST "version", "%d", object->version()));
                 }


### PR DESCRIPTION
the 64bit switchover is near (see http://lists.openstreetmap.org/pipermail/dev/2012-December/026354.html). The changes in this pull request make osmium 64bit proof and allow 3rd party applications to do the same (see https://github.com/MaZderMind/osm-history-splitter/compare/64bit).
