### PR TITLE
osmjs: enable absolute paths for the .js file

### DIFF
--- a/osmjs/osmjs.cpp
+++ b/osmjs/osmjs.cpp
@@ -66,6 +66,7 @@ void print_help() {
 
 std::string find_include_file(std::string filename) {
     std::vector<std::string> search_path;
+    search_path.push_back("/");
     search_path.push_back(".");
     search_path.push_back("js");
     search_path.push_back(std::string(getenv("HOME")) + "/.osmjs");


### PR DESCRIPTION
When specifying an absolute path, I got:

> $ /home/simon/src/osmium/osmjs/osmjs -2 -m -l sparsetable -i /home/simon/src/osmium/osmjs/js/osm2shape.js
> Could not find include file /home/simon/src/osmium/osmjs/js/osm2shape.js in search path (.:js:/home/simon/.osmjs:/usr/local/share/osmjs:/usr/share/osmjs)
