### PR TITLE
remove hard dependency on geos library.

### DIFF
--- a/include/osmium/handler.hpp
+++ b/include/osmium/handler.hpp
@@ -30,10 +30,11 @@ You should have received a copy of the Licenses along with Osmium. If not, see
 #include <osmium/osm/node.hpp>
 #include <osmium/osm/way.hpp>
 #include <osmium/osm/relation.hpp>
-#include <osmium/osm/area.hpp>
 
 namespace Osmium {
-
+    namespace OSM {
+       class Area;
+    }  // namespace OSM
     /**
      * @brief Handlers operate on %OSM data through callbacks.
      *


### PR DESCRIPTION
The typical usage of parsing osm files does not require handling of multipolygons (and area() call is no used) . However, handler.hpp  includes area.hpp file which in turn includes geos library. And that one defines int64 types in global scope which conflicts with other libraries i am using.
