### PR TITLE
define BOOST_TEST_DYN_LINK in CXXFLAGS rather than each test

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -29,8 +29,8 @@ test_file () {
     eval CFLAGS=`../get_options.sh --cflags $FILES`
     eval LIBS=`../get_options.sh --libs $FILES`
     echo "Checking $BOLD$1$NORM..."
-    echo $COMPILE $FILES $CFLAGS $LIBS -lboost_unit_test_framework
-    $COMPILE $FILES $CFLAGS $LIBS -lboost_unit_test_framework
+    echo $COMPILE $FILES $CFLAGS $LIBS -DBOOST_TEST_DYN_LINK -lboost_unit_test_framework
+    $COMPILE $FILES $CFLAGS $LIBS -DBOOST_TEST_DYN_LINK -lboost_unit_test_framework
     $VALGRIND ./tests
 }
 

--- a/test/t/geometry/test_linestring_geometry.cpp
+++ b/test/t/geometry/test_linestring_geometry.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/geometry/test_point_geometry.cpp
+++ b/test/t/geometry/test_point_geometry.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/geometry/test_polygon_geometry.cpp
+++ b/test/t/geometry/test_polygon_geometry.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/geometry_geos/test_point_geometry.cpp
+++ b/test/t/geometry_geos/test_point_geometry.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/geometry_ogr/test_geometry.cpp
+++ b/test/t/geometry_ogr/test_geometry.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osm/test_bounds.cpp
+++ b/test/t/osm/test_bounds.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osm/test_node.cpp
+++ b/test/t/osm/test_node.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osm/test_position.cpp
+++ b/test/t/osm/test_position.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osm/test_way_node.cpp
+++ b/test/t/osm/test_way_node.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osm/test_way_node_list.cpp
+++ b/test/t/osm/test_way_node_list.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/osmfile/test_filename.cpp
+++ b/test/t/osmfile/test_filename.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/tags/test_filter.cpp
+++ b/test/t/tags/test_filter.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/tags/test_regex_filter.cpp
+++ b/test/t/tags/test_regex_filter.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/tags/test_tag.cpp
+++ b/test/t/tags/test_tag.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/tags/test_to_string.cpp
+++ b/test/t/tags/test_to_string.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/t/utils/test_timestamp.cpp
+++ b/test/t/utils/test_timestamp.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #ifdef STAND_ALONE
 # define BOOST_TEST_MODULE Main
 #endif

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,3 +1,2 @@
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE Main
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This is a change to the tests only. The logic is that a developer may need to avoid `BOOST_TEST_DYN_LINK` from being defined and this change makes that easy to tweak in one location.

In my case I found that on OS X with boost 1.53 (and likely all recent versions) `BOOST_TEST_DYN_LINK` and a static `libboost_unit_test_framework.a` do not play well together. Linking to a dynamic library works, but a static library results in:

``` sh
Checking t/geometry/test_linestring_geometry.cpp...
g++ -I../include -I. -g -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -o tests -I/opt/boost-53/include test_main.cpp test_utils.cpp t/geometry/test_linestring_geometry.cpp -L/opt/boost-53/lib/ -lboost_unit_test_framework
Undefined symbols for architecture x86_64:
  "boost::unit_test::unit_test_main(bool (*)(), int, char**)", referenced from:
      _main in cc8zROUk.o
ld: symbol(s) not found for architecture x86_64
```

However linking a static `libboost_unit_test_framework.a` works just fine as long as `BOOST_TEST_DYN_LINK`  is not defined.
