### PR TITLE
fix compile by specifying void type for add_size

### DIFF
--- a/include/osmium/ser/buffer.hpp
+++ b/include/osmium/ser/buffer.hpp
@@ -43,7 +43,7 @@ namespace Osmium {
             Buffer(char* data, size_t size, boost::function<void()> full_callback) : m_data(data), m_size(size), m_pos(0), m_committed(0), m_full_callback(full_callback) {
             }
 
-            ~Buffer() {
+            virtual ~Buffer() {
             }
 
             char* ptr() const {
@@ -129,7 +129,7 @@ namespace Osmium {
                     m_buffer = new Osmium::Ser::Buffer(mem, size, boost::bind(&Malloc::full, this));
                 }
 
-                ~Malloc() {
+                virtual ~Malloc() {
                     free(m_buffer->ptr());
                     delete m_buffer;
                 }
@@ -160,6 +160,9 @@ namespace Osmium {
                 if (m_parent) {
                     m_parent->add_size(sizeof(length_t));
                 }
+            }
+
+            virtual ~Builder() {
             }
 
             virtual void add_size(length_t size) {
@@ -275,8 +278,8 @@ namespace Osmium {
 
         protected:
 
-            const char* const self() const {
-                return reinterpret_cast<const char* const>(this);
+            const char* self() const {
+                return reinterpret_cast<const char*>(this);
             }
 
         };
@@ -295,7 +298,7 @@ namespace Osmium {
                 return self() + sizeof(Object) + (type == 'n' ? sizeof(Osmium::OSM::Position) : 0);
             }
 
-            const char* const user() const {
+            const char* user() const {
                 return user_position() + sizeof(length_t);
             }
 
@@ -341,20 +344,20 @@ namespace Osmium {
 
         public:
 
-            Tag(const char* const data) : m_data(data) {
+            Tag(const char* data) : m_data(data) {
             }
 
-            const char* const key() const {
+            const char* key() const {
                 return m_data;
             }
 
-            const char* const value() const {
+            const char* value() const {
                 return m_data + strlen(m_data) + 1;
             }
 
         private:
 
-            const char* const m_data;
+            const char* m_data;
 
         }; // class Tag
 

--- a/include/osmium/ser/item.hpp
+++ b/include/osmium/ser/item.hpp
@@ -98,7 +98,7 @@ namespace Osmium {
             }
 
             void feed(THandler& handler) {
-                while (m_offset < m_data.size()) {
+                while (m_offset < static_cast<int>(m_data.size())) {
 //                    hexDump("item", &m_data[m_offset], 120);
                     const length_t length = *reinterpret_cast<const length_t*>(&m_data[m_offset]);
                     const Osmium::Ser::Item* item = reinterpret_cast<const Osmium::Ser::Item*>(&m_data[m_offset+sizeof(length_t)]);


### PR DESCRIPTION
Fixes this error:

``` cpp
In file included from ../include/osmium/ser/item.hpp:36:
../include/osmium/ser/buffer.hpp:165:21: error: C++ requires a type specifier for all declarations
            virtual add_size(length_t size) {
            ~~~~~~~ ^
```

And here are warnings fyi: https://gist.github.com/springmeyer/d73d50a51ddfc96c9cb7
