### PR TITLE
Allow to override CXX/CXXFLAGS through environment

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,8 +10,10 @@
 
 set -e
 
-CXX="g++"
-CXXFLAGS="-g -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long"
+if [ -z "$CXX" ]; then
+	CXX="g++"
+fi
+CXXFLAGS="$CXXFLAGS -g -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long"
 COMPILE="$CXX -I../include -I. $CXXFLAGS -o tests"
 
 if [ "x$1" = "x-v" ]; then


### PR DESCRIPTION
This is needed, for example, to support tests in FreeBSD port of osmium. Tests should respect systemwide compiler and flags (passed through environment), which among other things contain include/library paths critical for successful compilation.
