### PR TITLE
Allow to override CXX/CXXFLAGS through environment

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -10,8 +10,10 @@
 
 set -e
 
-CXX="g++"
-CXXFLAGS="-g -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long"
+if [ -z "$CXX" ]; then
+	CXX="g++"
+fi
+CXXFLAGS="$CXXFLAGS -g -Wall -Wextra -Wredundant-decls -Wdisabled-optimization -pedantic -Wctor-dtor-privacy -Wnon-virtual-dtor -Woverloaded-virtual -Wsign-promo -Wno-long-long"
 COMPILE="$CXX -I../include -I. $CXXFLAGS -o tests"
 
 if [ "x$1" = "x-v" ]; then


### PR DESCRIPTION
The reason with which #68 was closed is invalid: make is not involved in this change, and currently there's no way to build tests with proper systemwide CXX/CXXFLAGS settings without modifying the script.
